### PR TITLE
Added output to openhab-out node

### DIFF
--- a/77-openhab2.html
+++ b/77-openhab2.html
@@ -432,7 +432,7 @@
 		    payload:  {value:"", required:false}
 		},
         inputs: 1,
-        outputs: 0,
+        outputs: 1,
         icon: "node-red-contrib-openhab2.png",
         label: function() {
             return(this.name||this.itemname||"openhab2 out");

--- a/77-openhab2.js
+++ b/77-openhab2.js
@@ -465,7 +465,8 @@ module.exports = function(RED) {
 				openhabController.control(item, topic, payload,
 									function(body){
 										// no body expected for a command or update
-	                					node.status({fill:"green", shape: "dot", text: " "});
+										node.status({fill:"green", shape: "dot", text: " "});
+										node.send(msg);
 									},
 									function(err) {
 	                					node.status({fill:"red", shape: "ring", text: err});


### PR DESCRIPTION
Added output that passes the original message upon success. Useful for example when you want to send out a notification upon success. (Or do something else after successful completion of the openhab-out node)