### PR TITLE
404 errors when selecting Items in openhab2-in and openhab2-out node

### DIFF
--- a/77-openhab2.html
+++ b/77-openhab2.html
@@ -425,7 +425,7 @@
            			password: cntrlConfig.password
             	}
             	console.log("config = " + JSON.stringify(config));
-                $.getJSON("openhab2/items", config)
+                $.getJSON("/openhab2/items", config)
                   .done( function(data) {
 
                 	 itemSelectionEl.children().remove();


### PR DESCRIPTION
When the admin-panel isn't on the root path you'll get problems to access openhab2/items to fetch items.
So i added a "/" at line 428 to solve that problem.
May other have the same problem.